### PR TITLE
Remove duplicate members from `landscaper-maintainers` team

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -965,12 +965,8 @@ orgs:
         - maximilianbraun
         members:
         - reshnm
-        - Diaphteiros
-        - In-Ko
         - robertgraeff
         - enrico-kaack-comp
-        - guewa
-        - maximilianbraun
         privacy: closed
         repos:
           landscaper: maintain


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Some people of `landscaper-maintainers` team are mentioned as `maintainers` and `members` which make the peribolos job fail. This is fixed here.

```
{"component":"peribolos","level":"fatal","msg":"Configuration failed: failed to configure gardener teams: failed to update landscaper-maintainers members: users in both roles: diaphteiros, guewa, in-ko, maximilianbraun","severity":"fatal","time":"2026-06-26T15:09:52Z"}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
