### PR TITLE
chore(org): replace klocke-io with julestree in dashboard-related teams

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -69,6 +69,7 @@ orgs:
     - Gchbg
     - georgibaltiev
     - grolu
+    - julestree
     - guewa
     - hardikdr
     - hebelsan
@@ -242,6 +243,7 @@ orgs:
         maintainers:
         - petersutter
         - grolu
+        - julestree
         members:
         - AleksandarSavchev
         privacy: closed
@@ -379,7 +381,7 @@ orgs:
         - petersutter
         members:
         - grolu
-        - klocke-io
+        - julestree
         privacy: closed
         repos:
           dashboard: admin
@@ -495,7 +497,7 @@ orgs:
         - petersutter
         members:
         - grolu
-        - klocke-io
+        - julestree
         privacy: closed
         repos:
           gardenctl-v2: admin
@@ -885,7 +887,7 @@ orgs:
         - petersutter
         members:
         - grolu
-        - klocke-io
+        - julestree
         privacy: closed
         repos:
           gardenlogin: admin
@@ -894,6 +896,7 @@ orgs:
         maintainers:
         - petersutter
         - grolu
+        - julestree
         members:
         - AleksandarSavchev
         privacy: closed
@@ -1194,7 +1197,7 @@ orgs:
         - petersutter
         members:
         - grolu
-        - klocke-io
+        - julestree
         privacy: closed
         repos:
           terminal-controller-manager: admin


### PR DESCRIPTION
**What this PR does / why we need it**:
Niklas Klocke left and Julia Baum joined the dashboard team. Replaces klocke-io with julestree across the dashboard-related teams and adds julestree as an org member.

**Which issue(s) this PR fixes**:
Fixes #41 

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```