### PR TITLE
delete landscaper config

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -288,9 +288,6 @@ orgs:
           gardenlogin: admin
           ingress-default-backend: admin
           k8s-conformance: write
-          landscaper: write
-          landscaper-service: write
-          landscapercli: write
           logging: write
           machine-controller-manager: admin
           oidc-apps-controller: write
@@ -957,37 +954,6 @@ orgs:
         privacy: closed
         repos:
           gardener-extension-shoot-lakom-service: maintain
-      landscaper-maintainers:
-        description: ""
-        maintainers:
-        - Diaphteiros
-        - In-Ko
-        - guewa
-        - maximilianbraun
-        members:
-        - reshnm
-        - robertgraeff
-        - enrico-kaack-comp
-        privacy: closed
-        repos:
-          landscaper: maintain
-          landscaper-examples: maintain
-          landscaper-service: maintain
-          landscapercli: maintain
-        teams:
-          landscaper-admin:
-            description: ""
-            maintainers:
-            - Diaphteiros
-            - In-Ko
-            - guewa
-            - maximilianbraun
-            privacy: closed
-            repos:
-              landscaper: admin
-              landscaper-examples: admin
-              landscaper-service: admin
-              landscapercli: admin
       logging-maintainers:
         description: ""
         maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the org config for landscaper repos. They have been moved to `gardener-attic` organization.

Further development of landscaper components is done in `https://github.com/openmcp-project`

**Which issue(s) this PR fixes**:
Fixes #15

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
