### PR TITLE
Add STACKIT Maintainers to os-coreos and os-ubuntu

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -591,6 +591,9 @@ orgs:
         - ialidzhikov
         - MrBatschner
         - Roncossek
+        - dergeberl
+        - nschad
+        - robinschneider
         privacy: closed
         repos:
           gardener-extension-os-coreos: write
@@ -620,6 +623,9 @@ orgs:
         - Vincinator
         - MrBatschner
         - Roncossek
+        - dergeberl
+        - nschad
+        - robinschneider
         privacy: closed
         repos:
           gardener-extension-os-ubuntu: admin


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed with @timuthy 
This PR adds the STACKIT maintainers to gardener-extension-os-coreos and gardener-extension-os-ubuntu.
Based on the [gardener-extension-os-coreos/OWNERS_ALIASES](https://github.com/gardener/gardener-extension-os-coreos/blob/c1ed2cdc9150df8a8cda8ba36ac0f27b40050952/OWNERS_ALIASES) and [gardener-extension-os-ubuntu/OWNERS_ALIASES](https://github.com/gardener/gardener-extension-os-ubuntu/blob/be8960bd3744cc878fffd66cac8f107ca225f5b6/OWNERS_ALIASES), except @xoxys as he is not part of the org yet which is a dedicates process. 
