### PR TITLE
Drop `gardener-extension-equinix-metal`

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -277,7 +277,6 @@ orgs:
           gardener-extension-provider-alicloud: admin
           gardener-extension-provider-aws: admin
           gardener-extension-provider-azure: admin
-          gardener-extension-provider-equinix-metal: admin
           gardener-extension-provider-gcp: admin
           gardener-extension-provider-openstack: admin
           gardener-extension-registry-cache: admin
@@ -664,16 +663,6 @@ orgs:
           gardener-extension-provider-azure: admin
           machine-controller-manager-provider-azure: write
           terraformer: write
-      gardener-extension-provider-equinix-metal-maintainers:
-        description: Maintainers of repositories related to the EquinixMetal provider
-          extension.
-        maintainers:
-        - rfranzke
-        privacy: closed
-        repos:
-          gardener-extension-provider-equinix-metal: write
-          machine-controller-manager-provider-equinix-metal: write
-          terraformer: write
       gardener-extension-provider-gcp-maintainers:
         description: Maintainers of repositories related to the GCP provider extension.
         maintainers:
@@ -836,7 +825,6 @@ orgs:
           gardener-extension-provider-alicloud: write
           gardener-extension-provider-aws: write
           gardener-extension-provider-azure: write
-          gardener-extension-provider-equinix-metal: write
           gardener-extension-provider-gcp: write
           gardener-extension-provider-openstack: write
           gardener-extension-registry-cache: read
@@ -990,7 +978,6 @@ orgs:
           machine-controller-manager-provider-alicloud: write
           machine-controller-manager-provider-aws: admin
           machine-controller-manager-provider-azure: admin
-          machine-controller-manager-provider-equinix-metal: write
           machine-controller-manager-provider-gcp: admin
           machine-controller-manager-provider-openstack: write
           machine-controller-manager-provider-sampleprovider: admin


### PR DESCRIPTION
**What this PR does / why we need it**:
- Drop `gardener-extension-equinix-metal` from config
- The repo is archived and transition to `gardener-attic` org after the EQXM sunset.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/org/issues/18

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
