### PR TITLE
Add Velin-Todorov as GitHub org member

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -131,6 +131,7 @@ orgs:
     - tobschli
     - TuanAnh17N
     - vasu1124
+    - Velin-Todorov
     - VelmiraS
     - vicwicker
     - Vincinator


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
This PR adds @Velin-Todorov as GitHub org member.
For more details see https://github.com/gardener/org/issues/48.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/org/issues/48

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
