### PR TITLE
Allow `Membership Role Request` to be created for the `approver` role

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership_role.yaml
+++ b/.github/ISSUE_TEMPLATE/membership_role.yaml
@@ -23,6 +23,7 @@ body:
     description: Choose the community role you want to apply for as described in [community roles](https://gardener.cloud/docs/contribute/code/roles).
     options:
     - "reviewer"
+    - "approver"
 - id: repos
   type: input
   attributes:


### PR DESCRIPTION
**What this PR does / why we need it**:
We spot together with @dimityrmirchev @vpnachev and @rrhubenov that the `Membership Role Request` issue template does not allow the `approver` role to be selected.
See the [community roles](https://gardener.cloud/docs/contribute/code/roles).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
