### PR TITLE
Add GH issue template for new repository request

### DIFF
--- a/.github/ISSUE_TEMPLATE/repo_create.yaml
+++ b/.github/ISSUE_TEMPLATE/repo_create.yaml
@@ -1,7 +1,7 @@
 name: Repository creation
 description: Create a repository into the Gardener Org
 labels: [ "kind/task" ]
-title: "REQUEST: Create <github repo>"
+title: "Repository creation request for <github repo>"
 body:
 - id: repo_name
   type: input

--- a/.github/ISSUE_TEMPLATE/repo_create.yaml
+++ b/.github/ISSUE_TEMPLATE/repo_create.yaml
@@ -1,0 +1,51 @@
+name: Repository creation
+description: Create a repository into the Gardener Org
+labels: [ "kind/task" ]
+title: "REQUEST: Create <github repo>"
+body:
+- id: repo_name
+  type: input
+  attributes:
+    label: Requested name for new repository
+    placeholder: e.g. gardener-foo
+  validations:
+    required: true
+- id: visibility
+  type: dropdown
+  attributes:
+    label: What should be the repo visibility?
+    multiple: false
+    options:
+    - "public"
+    - "private"
+  validations:
+    required: true
+- id: owners
+  type: input
+  attributes:
+    label: Who should be listed as approvers in OWNERS/OWNERS_ALIASES?
+    placeholder: e.g. alice, bob
+  validations:
+    required: false
+- id: description
+  type: textarea
+  attributes:
+    label: What should the repo description be?
+    placeholder: |
+      By default we will set it to "created due to (link to this issue)"
+  validations:
+    required: false
+- id: sponsors
+  type: textarea
+  attributes:
+    label: Please provide GitHub handle of repository sponsors
+    placeholder: e.g. @alice, @bob
+  validations:
+    required: true
+- id: context
+  type: textarea
+  attributes:
+    label: Additional context for request
+    placeholder: Any additional information or context to describe the request.
+  validations:
+    required: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Add GH issue template for new repository request

The template is influenced by https://github.com/kubernetes/org/blob/5c7849b6c0d4bfb50860fcebd13b593a92417f8b/.github/ISSUE_TEMPLATE/repo-create.yml

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
