### PR TITLE
Fix link to community roles doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership_request.yaml
+++ b/.github/ISSUE_TEMPLATE/membership_request.yaml
@@ -30,7 +30,7 @@ body:
     options:
     - label: I've read the [Gardener contributor guideline](https://github.com/gardener/gardener/blob/master/CONTRIBUTING.md).
       required: true
-    - label: I fulfill all requirements of the requested membership its responsibilities (see [community roles](https://gardener.cloud/docs/contribute/code/roles)).
+    - label: I fulfill all requirements of the requested membership its responsibilities (see [community roles](https://gardener.cloud/contribute/contribution-process/roles/)).
       required: true
     - label: I verified my sponsors have the required community role.
       required: true

--- a/.github/ISSUE_TEMPLATE/membership_role.yaml
+++ b/.github/ISSUE_TEMPLATE/membership_role.yaml
@@ -20,7 +20,7 @@ body:
   type: dropdown
   attributes:
     label: "Requested Role"
-    description: Choose the community role you want to apply for as described in [community roles](https://gardener.cloud/docs/contribute/code/roles).
+    description: Choose the community role you want to apply for as described in [community roles](https://gardener.cloud/contribute/contribution-process/roles/).
     options:
     - "reviewer"
     - "approver"
@@ -38,7 +38,7 @@ body:
     options:
     - label: I've read the [Gardener contributor guideline](https://github.com/gardener/gardener/blob/master/CONTRIBUTING.md).
       required: true
-    - label: I fulfill all requirements of the requested role and acknowledge its responsibilities (see [community roles](https://gardener.cloud/docs/contribute/code/roles)).
+    - label: I fulfill all requirements of the requested role and acknowledge its responsibilities (see [community roles](https://gardener.cloud/contribute/contribution-process/roles/)).
       required: true
     - label: I verified my sponsors have the required community role.
       required: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix link to community roles doc

https://gardener.cloud/docs/contribute/code/roles is redirecting me to https://gardener.cloud/contribute/contribution-process/roles/, so let's fix this in-code.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @n-boshnakov


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
