### PR TITLE
Grant Security Managers read access to `gardener-ghsa-tracker` repo

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -1194,6 +1194,8 @@ orgs:
         - donistz
         - HeckEK
         privacy: closed
+        repos:
+          gardener-ghsa-tracker: read
       terminal-controller-manager-maintainers:
         description: ""
         maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Grant Security Managers read access to `gardener-ghsa-tracker` repo

**Which issue(s) this PR fixes**:
Related to #64 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```


/cc @dimityrmirchev 