### PR TITLE
Add gardener-extension-diki repository to maintainers list

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -419,6 +419,7 @@ orgs:
         repos:
           diki: maintain
           diki-operator: maintain
+          gardener-extension-diki: maintain
       documentation-maintainers:
         description: Gardener website and documentation maintainers
         maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/org/issues/21 as https://github.com/gardener/enhancements/pull/64 was merged.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
