### PR TITLE
Add DobromirNPeev and Velin-Todorov to the `gardener-triage` team

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -880,12 +880,12 @@ orgs:
         description: Gardener triage – Members have write access to repositories to edit issues that belong to others as well (e.g. umbrella issues).
         members:
           - dimitar-kostadinov
+          - DobromirNPeev
           - RadaBDimitrova
           - timebertt
+          - Velin-Todorov
           - vitanovs
           - vmileva
-          - DobromirNPeev
-          - Velin-Todorov
         privacy: closed
         repos:
           gardener: write

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -884,6 +884,8 @@ orgs:
           - timebertt
           - vitanovs
           - vmileva
+          - DobromirNPeev
+          - Velin-Todorov
         privacy: closed
         repos:
           gardener: write


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Dobromir Peev and Velin Todorov as part of gardener-triage team and grant them write access

**Which issue(s) this PR fixes**:
No issue

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
